### PR TITLE
No need to append key prefix for template config

### DIFF
--- a/bin/git-pr-release
+++ b/bin/git-pr-release
@@ -87,7 +87,7 @@ def build_pr_title_and_body(prs)
 
   template = DEFAULT_PR_TEMPLATE
 
-  if path = git_config('pr-release.template')
+  if path = git_config('template')
     template_path = File.join(git('rev-parse', '--show-toplevel').first.chomp, path)
     template = File.read(template_path)
   end


### PR DESCRIPTION
`git_config('pr-release.template')` loads config value from key `pr-release.pr-release.template`.
