### PR TITLE
add --dump options which dump pull-request data in JSON format

### DIFF
--- a/bin/git-pr-release
+++ b/bin/git-pr-release
@@ -129,7 +129,7 @@ end
 def dump_result_as_json(release_pr, merged_prs)
   puts( {
     :release_pull_request => (release_pr ? PullRequest.new(release_pr) : DummyPullRequest.new).to_hash,
-    :merged_pull_requeste => merged_prs.map { |pr| PullRequest.new(pr).to_hash }
+    :merged_pull_requests => merged_prs.map { |pr| PullRequest.new(pr).to_hash }
   }.to_json )
 end
 


### PR DESCRIPTION
To use result of created release PR information I added `--dump` option that dumps pull-request info. in JSON format. 

To implement this option, I changed `say` method to print messages to STDERR.
