### PR TITLE
Support two factor auth

### DIFF
--- a/bin/git-pr-release
+++ b/bin/git-pr-release
@@ -200,7 +200,7 @@ def request_authorization(client, two_factor_code)
   begin
     auth = client.create_authorization(params)
   rescue Octokit::OneTimePasswordRequired
-    two_factor_code = ask('two-factor authentication code?')
+    two_factor_code = ask('two-factor authentication code? ')
     auth = request_authorization(client, two_factor_code)
   end
 


### PR DESCRIPTION
Currently `git-pr-release` don't support two factor auth in interactive configuration mode. This patch shows prompt `two-factor authentication code?` and try to request again.
