### PR TITLE
Support ruby 1.9

### DIFF
--- a/bin/git-pr-release
+++ b/bin/git-pr-release
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# -*- coding: utf-8 -*-
 
 require 'uri'
 require 'erb'


### PR DESCRIPTION
`git-pr-release` caused crash on ruby 1.9.3 with below error.

```
git-pr-release:126:in `split': invalid byte sequence in US-ASCII (ArgumentError)
```

 I added magic comment to use UTF-8.
But I don't know this is ordinary manner on ruby because I'm not pro Rubyist :sweat_smile:
