### PR TITLE
Support review requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ You can specify this value by `GIT_PR_RELEASE_LABELS` environment variable.
 
 If not specified, any labels will not be added for PRs.
 
+### `pr-release.reviewers`
+
+The reviewers list for adding to pull requests created.
+This value should be comma-separated strings.
+
+You can specify this value by `GIT_PR_RELEASE_REVIEWERS` environment variable.
+
+If not specified, any reviewers will not be added for PRs.
+
+### `pr-release.team-reviewers`
+
+The team reviewers list for adding to pull requests created.
+This value should be comma-separated strings.
+
+You can specify this value by `GIT_PR_RELEASE_TEAM_REVIEWERS` environment variable.
+
+If not specified, any team reviewers will not be added for PRs.
+
 
 Errors and exit statuses
 ------------------------

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -150,6 +150,21 @@ module Git
             end
           end
 
+          reviewers = ENV.fetch('GIT_PR_RELEASE_REVIEWERS') { git_config('reviewers') } || ''
+          team_reviewers = ENV.fetch('GIT_PR_RELEASE_TEAM_REVIEWERS') { git_config('team-reviewers') } || ''
+          if not reviewers.empty? or not team_reviewers.empty?
+            reviewers = reviewers.split(/\s*,\s*/)
+            team_reviewers = team_reviewers.split(/\s*,\s*/)
+            pull_request_with_reviewers = client.request_pull_request_review(
+              repository, release_pr.number, reviewers: reviewers, team_reviewers: team_reviewers
+            )
+
+            unless pull_request_with_reviewers
+              say 'Failed to add reviewers to a pull request', :error
+              exit 5
+            end
+          end
+
           say "#{create_mode ? 'Created' : 'Updated'} pull request: #{updated_pull_request.rels[:html].href}", :notice
           dump_result_as_json( release_pr, merged_prs, changed_files ) if @json
         end


### PR DESCRIPTION
We send a review request to some teams in release pull requests, so I've implemented a feature to send a review request using [Review Requests API](https://developer.github.com/v3/pulls/review_requests/#create-a-review-request).