### PR TITLE
[DNM] Fix no-fetch behavior

### DIFF
--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -27,7 +27,7 @@ module Git
               @json = v
             end
             opts.on('--no-fetch', 'Do not fetch from remote repo before determining target PRs (CI friendly)') do |v|
-              @no_fetch = v
+              @no_fetch = !v
             end
           end.parse!
 


### PR DESCRIPTION
Ref: #18 

An option with `no-` prefix returns `false`.

https://docs.ruby-lang.org/ja/latest/class/OptionParser.html

> また、"no-" をオプションの先頭に付けた場合は値が反転します。

---

Currently `@no_fetch` is either `nil` or `false`, so `git :remote, 'update', 'origin' unless @no_fetch` will be executed always.