### PR TITLE
List PR API needs head user or head organization and branch name

### DIFF
--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -151,7 +151,8 @@ module Git
 
         def detect_existing_release_pr
           say 'Searching for existing release pull requests...', :info
-          client.pull_requests(repository, head: staging_branch, base: production_branch).first
+          user=repository.split("/")[0]
+          client.pull_requests(repository, head: "#{user}:#{staging_branch}", base: production_branch).first
         end
 
         def prepare_release_pr


### PR DESCRIPTION
GitHub API list-pull-requests によると、

https://developer.github.com/v3/pulls/#list-pull-requests

> Filter pulls by head user or head organization and branch name in the format of user:ref-name or organization:ref-name. For example: github:new-script-format or octocat:test-branch.

`head` には `head user or head organization` が必須であったようで、 `base` のみで絞り込まれている。

このため、`base == production_branch` のPRが複数存在している場合に、取得したPRが、 `head == staging_branch` であることもあれば、`head != staging_branch` であることもあり、意図しないPRを git-pr-release が更新することがある。

`head` パラメータをAPI仕様どおり指定することで、本来あるべきだった挙動にする。