### PR TITLE
support `GIT_PR_RELEASE_MENTION` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ You can specify this value by `GIT_PR_RELEASE_LABELS` environment variable.
 
 If not specified, any labels will not be added for PRs.
 
+### `pr-release.mention`
+
+The name that is listed next to each PR title.
+Accepted values: `author`
+
+You can specify this value by `GIT_PR_RELEASE_MENTION` environment variable.
+
+If not specified, the mention will be the PR assignee
+
 
 Errors and exit statuses
 ------------------------

--- a/lib/git/pr/release/pull_request.rb
+++ b/lib/git/pr/release/pull_request.rb
@@ -34,7 +34,7 @@ module Git
         end
 
         def self.mention_type
-          @mention_type ||= (git_config('mention') || 'default')
+          @mention_type ||= (ENV.fetch('GIT_PR_RELEASE_MENTION') { git_config('mention') } || 'default')
         end
       end
     end


### PR DESCRIPTION
- right now it has to be git config
- adds an environment variable as an option to set this to author
- updates readme to surface this config