### PR TITLE
Suppress warning for ERB

### DIFF
--- a/lib/git/pr/release/util.rb
+++ b/lib/git/pr/release/util.rb
@@ -94,7 +94,11 @@ ERB
                        DEFAULT_PR_TEMPLATE
                      end
 
-          erb = ERB.new template, nil, '-'
+          erb = if RUBY_VERSION >= '2.6'
+                  ERB.new template, trim_mode: '-'
+                else
+                  ERB.new template, nil, '-'
+                end
           content = erb.result binding
           content.split(/\n/, 2)
         end


### PR DESCRIPTION
Because ERB changed how to handle initialization arguments since Ruby 2.6.0, it warns `lib/git/pr/release/util.rb` 's usage.

```
/Users/ohbarye/.ghq/github.com/ohbarye/git-pr-release/lib/git/pr/release/util.rb:97: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/Users/ohbarye/.ghq/github.com/ohbarye/git-pr-release/lib/git/pr/release/util.rb:97: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```

Ruby commit: https://github.com/ruby/ruby/commit/cc777d09f44fa909a336ba14f3aa802ffe16e010
Rubocop's handling: https://github.com/rubocop-hq/rubocop/pull/5614/files

## Testing

Run `rspec` with v2.6.0 or above.

### Before

There're warnings for ERB.

```shell
$ bundle exec rspec

Randomized with seed 20925
.../Users/ohbarye/.ghq/github.com/ohbarye/git-pr-release/lib/git/pr/release/util.rb:97: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/Users/ohbarye/.ghq/github.com/ohbarye/git-pr-release/lib/git/pr/release/util.rb:97: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
./Users/ohbarye/.ghq/github.com/ohbarye/git-pr-release/lib/git/pr/release/util.rb:97: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/Users/ohbarye/.ghq/github.com/ohbarye/git-pr-release/lib/git/pr/release/util.rb:97: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
.....To be released: #3 Provides a creating release pull-request object for template
To be released: #4 use user who create PR if there is no assignee
.....Dry-run. Not updating PR
Release 2020-01-04 16:51:09 +0900
- [ ] #3 Provides a creating release pull-request object for template @hakobe
- [ ] #4 use user who create PR if there is no assignee @motemen
.Created pull request: https://github.com/motemen/git-pr-release/pull/1
.Updated pull request: https://github.com/motemen/git-pr-release/pull/1023
.Searching for existing release pull requests...
.Searching for existing release pull requests...
..No pull requests to be released
........../Users/ohbarye/.ghq/github.com/ohbarye/git-pr-release/lib/git/pr/release/cli.rb:59: warning: already initialized constant OpenSSL::SSL::VERIFY_PEER
.

Finished in 0.62901 seconds (files took 0.48012 seconds to load)
31 examples, 0 failures

Randomized with seed 20925
```

### After

No warnings for ERB.

```shell
$ bundle exec rspec

Randomized with seed 53861
............../Users/ohbarye/.ghq/github.com/ohbarye/git-pr-release/lib/git/pr/release/cli.rb:59: warning: already initialized constant OpenSSL::SSL::VERIFY_PEER
..........No pull requests to be released
.To be released: #3 Provides a creating release pull-request object for template
To be released: #4 use user who create PR if there is no assignee
.Created pull request: https://github.com/motemen/git-pr-release/pull/1
.Updated pull request: https://github.com/motemen/git-pr-release/pull/1023
.Dry-run. Not updating PR
Release 2020-01-04 16:51:09 +0900
- [ ] #3 Provides a creating release pull-request object for template @hakobe
- [ ] #4 use user who create PR if there is no assignee @motemen
.Searching for existing release pull requests...
.Searching for existing release pull requests...
.

Finished in 0.70155 seconds (files took 0.6799 seconds to load)
31 examples, 0 failures

Randomized with seed 53861
```