### PR TITLE
Aggregate labels from merged pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,18 @@ You can specify this value by `GIT_PR_RELEASE_LABELS` environment variable.
 
 If not specified, any labels will not be added for PRs.
 
+### `pr-release.aggregate_labels`
+
+If it is `true`, `git-pr-release` aggregates labels from merged pull requests and add them to a created pull request.
+
+If also `pr-release.labels` has values, `git-pr-release` merges aggregates labels and labels given by `pr-release.labels`.
+
+You can specify this value by `GIT_PR_RELEASE_AGGREGATE_LABELS` environment variable.
+
+Default value: `false`.
+
+If not specified, it doesn't aggregate labels from merged pull requests.
+
 ### `pr-release.mention`
 
 The name that is listed next to each PR title.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can specify this value by `GIT_PR_RELEASE_LABELS` environment variable.
 
 If not specified, any labels will not be added for PRs.
 
-### `pr-release.aggregate_labels`
+### `pr-release.aggregate-labels`
 
 If it is `true`, `git-pr-release` aggregates labels from merged pull requests and add them to a created pull request.
 

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -6,7 +6,7 @@ module Git
     module Release
       class CLI
         include Git::Pr::Release::Util
-        attr_reader :repository, :production_branch, :staging_branch, :template_path, :labels
+        attr_reader :repository, :production_branch, :staging_branch, :template_path, :labels, :aggregate_labels
 
         def self.start
           result = self.new.start
@@ -67,6 +67,7 @@ module Git
           @production_branch = ENV.fetch('GIT_PR_RELEASE_BRANCH_PRODUCTION') { git_config('branch.production') } || 'master'
           @staging_branch    = ENV.fetch('GIT_PR_RELEASE_BRANCH_STAGING') { git_config('branch.staging') }       || 'staging'
           @template_path     = ENV.fetch('GIT_PR_RELEASE_TEMPLATE') { git_config('template') }
+          @aggregate_labels  = ENV.fetch('GIT_PR_RELEASE_AGGREGATE_LABELS') { git_config('aggregate_labels') } == 'true'
 
           _labels = ENV.fetch('GIT_PR_RELEASE_LABELS') { git_config('labels') }
           @labels = _labels && _labels.split(/\s*,\s*/) || []
@@ -75,7 +76,8 @@ module Git
           say "Production branch: #{production_branch}", :debug
           say "Staging branch:    #{staging_branch}", :debug
           say "Template path:     #{template_path}", :debug
-          say "Labels             #{labels}", :debug
+          say "Labels:            #{labels}#{aggregate_labels ? ' + labels on merged PRs' : ''}", :debug
+          say "Aggregate Labels:  #{aggregate_labels}", :debug
         end
 
         def fetch_merged_prs
@@ -111,6 +113,13 @@ module Git
             pr = client.pull_request repository, nr
             say "To be released: ##{pr.number} #{pr.title}", :notice
             pr
+          end
+
+          if aggregate_labels
+            merged_prs_labels = merged_prs.flat_map do |pr|
+              pr.labels.map(&:name)
+            end
+            @labels = (labels + merged_prs_labels).uniq
           end
 
           merged_prs

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -67,7 +67,7 @@ module Git
           @production_branch = ENV.fetch('GIT_PR_RELEASE_BRANCH_PRODUCTION') { git_config('branch.production') } || 'master'
           @staging_branch    = ENV.fetch('GIT_PR_RELEASE_BRANCH_STAGING') { git_config('branch.staging') }       || 'staging'
           @template_path     = ENV.fetch('GIT_PR_RELEASE_TEMPLATE') { git_config('template') }
-          @aggregate_labels  = ENV.fetch('GIT_PR_RELEASE_AGGREGATE_LABELS') { git_config('aggregate_labels') } == 'true'
+          @aggregate_labels  = ENV.fetch('GIT_PR_RELEASE_AGGREGATE_LABELS') { git_config('aggregate-labels') } == 'true'
 
           _labels = ENV.fetch('GIT_PR_RELEASE_LABELS') { git_config('labels') }
           @labels = _labels && _labels.split(/\s*,\s*/) || []

--- a/spec/fixtures/file/pr_3.yml
+++ b/spec/fixtures/file/pr_3.yml
@@ -37,12 +37,19 @@
 :closed_at: 2014-03-13 11:42:18.000000000 Z
 :merged_at: 2014-03-13 11:42:18.000000000 Z
 :merge_commit_sha: 2ff5c670d9bebde490a6651f185ecba6cb09b48d
-:assignee: 
+:assignee:
 :assignees: []
 :requested_reviewers: []
 :requested_teams: []
-:labels: []
-:milestone: 
+:labels:
+  - :id: 208045946,
+    :node_id: "MDU6TGFiZWwyMDgwNDU5NDY="
+    :url: "https://api.github.com/repos/octocat/Hello-World/labels/bug"
+    :name: "bug"
+    :description: "Something isn't working"
+    :color: "f29513"
+    :default: true
+:milestone:
 :commits_url: https://api.github.com/repos/motemen/git-pr-release/pulls/3/commits
 :review_comments_url: https://api.github.com/repos/motemen/git-pr-release/pulls/3/comments
 :review_comment_url: https://api.github.com/repos/motemen/git-pr-release/pulls/comments{/number}
@@ -155,10 +162,10 @@
     :has_wiki: true
     :has_pages: false
     :forks_count: 0
-    :mirror_url: 
+    :mirror_url:
     :archived: false
     :open_issues_count: 0
-    :license: 
+    :license:
     :forks: 0
     :open_issues: 0
     :watchers: 0
@@ -269,7 +276,7 @@
     :has_wiki: true
     :has_pages: false
     :forks_count: 28
-    :mirror_url: 
+    :mirror_url:
     :archived: false
     :open_issues_count: 6
     :license:
@@ -301,8 +308,8 @@
     :href: https://api.github.com/repos/motemen/git-pr-release/statuses/5c977a1827387ac7b7a85c7b827ee119165f1823
 :author_association: COLLABORATOR
 :merged: true
-:mergeable: 
-:rebaseable: 
+:mergeable:
+:rebaseable:
 :mergeable_state: unknown
 :merged_by:
   :login: motemen

--- a/spec/fixtures/file/pr_4.yml
+++ b/spec/fixtures/file/pr_4.yml
@@ -35,12 +35,19 @@
 :closed_at: 2014-03-26 10:49:03.000000000 Z
 :merged_at: 2014-03-26 10:49:03.000000000 Z
 :merge_commit_sha: 19dd4309bfac0b0358e7e87f48a007ef54634140
-:assignee: 
+:assignee:
 :assignees: []
 :requested_reviewers: []
 :requested_teams: []
-:labels: []
-:milestone: 
+:labels:
+  - :id: 208045946,
+    :node_id: "MDU6TGFiZWwyMDgwNDU5NDY="
+    :url: "https://api.github.com/repos/octocat/Hello-World/labels/bug"
+    :name: "enhancement"
+    :description: "Something isn't working"
+    :color: "f29513"
+    :default: true
+:milestone:
 :commits_url: https://api.github.com/repos/motemen/git-pr-release/pulls/4/commits
 :review_comments_url: https://api.github.com/repos/motemen/git-pr-release/pulls/4/comments
 :review_comment_url: https://api.github.com/repos/motemen/git-pr-release/pulls/comments{/number}
@@ -152,7 +159,7 @@
     :has_wiki: true
     :has_pages: false
     :forks_count: 28
-    :mirror_url: 
+    :mirror_url:
     :archived: false
     :open_issues_count: 6
     :license:
@@ -271,7 +278,7 @@
     :has_wiki: true
     :has_pages: false
     :forks_count: 28
-    :mirror_url: 
+    :mirror_url:
     :archived: false
     :open_issues_count: 6
     :license:
@@ -303,8 +310,8 @@
     :href: https://api.github.com/repos/motemen/git-pr-release/statuses/42bd43b80c973c8f348df3521745201be05bf194
 :author_association: COLLABORATOR
 :merged: true
-:mergeable: 
-:rebaseable: 
+:mergeable:
+:rebaseable:
 :mergeable_state: unknown
 :merged_by:
   :login: motemen

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe Git::Pr::Release::CLI do
 
       context "With git_config" do
         before {
-          allow(@cli).to receive(:git_config).with("aggregate_labels") { "true" }
+          allow(@cli).to receive(:git_config).with("aggregate-labels") { "true" }
         }
 
         it "set aggregate_labels" do

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -181,6 +181,47 @@ RSpec.describe Git::Pr::Release::CLI do
         end
       end
     end
+
+    describe "aggregate_labels" do
+      context "With ENV" do
+        around do |example|
+          original = ENV.to_hash
+          begin
+            ENV["GIT_PR_RELEASE_AGGREGATE_LABELS"] = env_labels
+            example.run
+          ensure
+            ENV.replace(original)
+          end
+        end
+
+        context "string" do
+          let(:env_labels) { "true" }
+          it "set aggregate_labels" do
+            subject
+            expect(@cli.aggregate_labels).to eq true
+          end
+        end
+
+        context "empty string" do
+          let(:env_labels) { "" }
+          it "set aggregate_labels as default" do
+            subject
+            expect(@cli.aggregate_labels).to eq false
+          end
+        end
+      end
+
+      context "With git_config" do
+        before {
+          allow(@cli).to receive(:git_config).with("aggregate_labels") { "true" }
+        }
+
+        it "set aggregate_labels" do
+          subject
+          expect(@cli.aggregate_labels).to eq true
+        end
+      end
+    end
   end
 
   describe "#fetch_merged_prs" do
@@ -227,6 +268,23 @@ RSpec.describe Git::Pr::Release::CLI do
     }
 
     it { is_expected.to eq [@pr_3, @pr_4] }
+
+    context "aggregate_labels option is true" do
+      around do |example|
+        original = ENV.to_hash
+        begin
+          ENV["GIT_PR_RELEASE_LABELS"] = 'release'
+          ENV["GIT_PR_RELEASE_AGGREGATE_LABELS"] = 'true'
+          example.run
+        ensure
+          ENV.replace(original)
+        end
+      end
+
+      it "merges labels given as GIT_PR_RELEASE_LABELS and labels on merged PRs" do
+        expect { subject }.to change { @cli.labels }.from(['release']).to(['release', 'bug', 'enhancement'])
+      end
+    end
   end
 
   describe "#create_release_pr" do


### PR DESCRIPTION
@onk @motemen 

## Issue

Closes #54 

## Changes

As described in https://github.com/x-motemen/git-pr-release/issues/54, I added `aggregate_labels` feature.

- Add `pr-release.aggregate_labels` config (or `GIT_RELEASE_PR_AGGREGATE_LABELS`).
  - It accepts boolean-ish value: `"true"` or anything
  - Only when it is `"true"`, `git-release-pr` aggregates labels from merged pull requests.
- What if `pr-release.labels` is given at the same time?
  - Merge aggregated labels and `pr-release.labels` setting.
    - `pr-release.labels=foo,bar` and aggregated labels are `baz`, then labels would be `["foo", "bar", "baz"]`.

## Testing

That worked well on my own 

```shell
$ GIT_PR_RELEASE_BRANCH_STAGING=release GIT_PR_RELEASE_LABELS=release GIT_PR_RELEASE_AGGREGATE_LABELS=true bundle exec git-pr-release
```

Merged PRs have labels|Created PR has labels
---|---
![image](https://user-images.githubusercontent.com/1811616/93864369-c3334a80-fcff-11ea-9543-0e41d392d851.png)|![image](https://user-images.githubusercontent.com/1811616/93864493-f37ae900-fcff-11ea-9cb0-8fcead843a6c.png)


## Review Points

- Is `aggregate_labels` an appropriate name?
  - ideas: `reuse_labels`, `summarize_labels`... etc.
- Should `aggregate_labels` be given as a command line arg, not environment variable or git config?
  - As like `--dry-run`, `--no-fecth`, `aggregate_labels` is boolean-ish value. So I wonder if it should be. (It depends on this gem's command line design.)
