### PR TITLE
Remove exit statuses that are never returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,18 +92,6 @@ Errors and exit statuses
 
 exit status is 1.
 
-### Failed to create a new pull request
-
-exit status is 2.
-
-### Failed to update a pull request
-
-exit status is 3.
-
-### Failed to add labels
-
-exit status is 4.
-
 Author
 ------
 


### PR DESCRIPTION
## Change

The README describes exit status 2, 3, 4 for each error. But the code to return those statuses have disappeared at https://github.com/x-motemen/git-pr-release/commit/7afcbc47b0ffc36f4cdd69537b7e911948b8e191 and they are never returned since v1.2.0.

Therefore, I'd say the description on README is obsolete and should be updated.