### PR TITLE
Make stable test with timezone

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,15 @@ RSpec.configure do |config|
   config.order = :random
   Kernel.srand config.seed
 
+  config.around(:each) do |example|
+    begin
+      ENV['TZ'], old = 'Asia/Tokyo', ENV['TZ']
+      example.run
+    ensure
+      ENV['TZ'] = old
+    end
+  end
+
   config.after do
     Timecop.return
   end


### PR DESCRIPTION
Without this change, on docker image `ruby:2.5.8` fails running tests

```
  1) Git::Pr::Release#build_pr_title_and_body without template_path is expected to eq "Release 2019-02-20 22:58:35 +0900"
     Failure/Error: expect(pr_title).to eq "Release 2019-02-20 22:58:35 +0900"

       expected: "Release 2019-02-20 22:58:35 +0900"
            got: "Release 2019-02-20 22:58:35 +0000"

       (compared using ==)
     # ./spec/git/pr/release_spec.rb:25:in `block (4 levels) in <top (required)>'
     # /usr/local/bundle/gems/webmock-3.12.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
```