### PR TITLE
Suppress ruby warnings

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
+--warnings
 --require spec_helper

--- a/git-pr-release.gemspec
+++ b/git-pr-release.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.4.0')
 
   spec.add_dependency 'octokit'
   spec.add_dependency 'highline'

--- a/git-pr-release.gemspec
+++ b/git-pr-release.gemspec
@@ -17,10 +17,13 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
+
   spec.add_dependency 'octokit'
   spec.add_dependency 'highline'
   spec.add_dependency 'colorize'
   spec.add_dependency 'diff-lcs'
+  spec.add_dependency 'erb', '>= 2.2.2'
 
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'timecop'

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -84,12 +84,12 @@ module Git
           merged_feature_head_sha1s = git(
             :log, '--merges', '--pretty=format:%P', "origin/#{production_branch}..origin/#{staging_branch}"
           ).map do |line|
-            _main_sha1, feature_sha1 = line.chomp.split /\s+/
+            _main_sha1, feature_sha1 = line.chomp.split(/\s+/)
             feature_sha1
           end
 
           merged_pull_request_numbers = git('ls-remote', 'origin', 'refs/pull/*/head').map do |line|
-            sha1, ref = line.chomp.split /\s+/
+            sha1, ref = line.chomp.split(/\s+/)
 
             if merged_feature_head_sha1s.include? sha1
               if %r<^refs/pull/(\d+)/head$>.match ref

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -84,7 +84,7 @@ module Git
           merged_feature_head_sha1s = git(
             :log, '--merges', '--pretty=format:%P', "origin/#{production_branch}..origin/#{staging_branch}"
           ).map do |line|
-            main_sha1, feature_sha1 = line.chomp.split /\s+/
+            _main_sha1, feature_sha1 = line.chomp.split /\s+/
             feature_sha1
           end
 

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -56,6 +56,9 @@ module Git
 
           if host
             # GitHub:Enterprise
+            if OpenSSL::SSL.const_defined?(:VERIFY_PEER)
+              OpenSSL::SSL.__send__(:remove_const, :VERIFY_PEER)
+            end
             OpenSSL::SSL.const_set :VERIFY_PEER, OpenSSL::SSL::VERIFY_NONE # XXX
 
             Octokit.configure do |c|

--- a/lib/git/pr/release/util.rb
+++ b/lib/git/pr/release/util.rb
@@ -84,8 +84,8 @@ Release <%= Time.now %>
 ERB
 
         def build_pr_title_and_body(release_pr, merged_prs, changed_files, template_path)
-          release_pull_request = target_pull_request = release_pr ? PullRequest.new(release_pr) : DummyPullRequest.new
-          merged_pull_requests = pull_requests = merged_prs.map { |pr| PullRequest.new(pr) }
+          _release_pull_request = target_pull_request = release_pr ? PullRequest.new(release_pr) : DummyPullRequest.new
+          _merged_pull_requests = pull_requests = merged_prs.map { |pr| PullRequest.new(pr) }
 
           template = if template_path
                        template_fullpath = File.join(git('rev-parse', '--show-toplevel').first.chomp, template_path)
@@ -127,8 +127,8 @@ ERB
           Diff::LCS.traverse_balanced(old_body_unchecked.split(/\r?\n/), new_body.split(/\r?\n/)) do |event|
             say "diff: #{event.inspect}", :trace
             action, old, new = *event
-            old_nr, old_line = *old
-            new_nr, new_line = *new
+            _old_nr, old_line = *old
+            _new_nr, new_line = *new
 
             case action
             when '=', '+'

--- a/lib/git/pr/release/util.rb
+++ b/lib/git/pr/release/util.rb
@@ -84,8 +84,8 @@ Release <%= Time.now %>
 ERB
 
         def build_pr_title_and_body(release_pr, merged_prs, changed_files, template_path)
-          _release_pull_request = target_pull_request = release_pr ? PullRequest.new(release_pr) : DummyPullRequest.new
-          _merged_pull_requests = pull_requests = merged_prs.map { |pr| PullRequest.new(pr) }
+          release_pull_request = target_pull_request = release_pr ? PullRequest.new(release_pr) : DummyPullRequest.new
+          merged_pull_requests = pull_requests = merged_prs.map { |pr| PullRequest.new(pr) }
 
           template = if template_path
                        template_fullpath = File.join(git('rev-parse', '--show-toplevel').first.chomp, template_path)
@@ -94,12 +94,13 @@ ERB
                        DEFAULT_PR_TEMPLATE
                      end
 
-          erb = if RUBY_VERSION >= '2.6'
-                  ERB.new template, trim_mode: '-'
-                else
-                  ERB.new template, nil, '-'
-                end
-          content = erb.result binding
+          erb = ERB.new template, trim_mode: '-'
+          content = erb.result_with_hash(
+            release_pull_request: release_pull_request,
+            target_pull_request: target_pull_request,
+            merged_pull_requests: merged_pull_requests,
+            pull_requests: pull_requests
+          )
           content.split(/\n/, 2)
         end
 

--- a/lib/git/pr/release/util.rb
+++ b/lib/git/pr/release/util.rb
@@ -122,7 +122,7 @@ ERB
               check_status[m[:issue_number]] = m[:check_value]
             }
           }
-          old_body_unchecked = old_body.gsub /^- \[[ x]\] \#(\d+)/, '- [ ] #\1'
+          old_body_unchecked = old_body.gsub(/^- \[[ x]\] \#(\d+)/, '- [ ] #\1')
 
           Diff::LCS.traverse_balanced(old_body_unchecked.split(/\r?\n/), new_body.split(/\r?\n/)) do |event|
             say "diff: #{event.inspect}", :trace
@@ -157,7 +157,7 @@ ERB
           merged_body = pr_body_lines.join("\n")
           check_status.each { |issue_number, check_value|
             say "Update pull-request checkbox \##{issue_number} to #{check_value}.", :trace
-            merged_body.gsub! /^- \[ \] \##{issue_number}/, "- [#{check_value}] \##{issue_number}"
+            merged_body.gsub!(/^- \[ \] \##{issue_number}/, "- [#{check_value}] \##{issue_number}")
           }
 
           merged_body


### PR DESCRIPTION
This PR just aims to remove ruby warnings.
But I bumped supported ruby version and dependency, because of clarify to use latest `erb`.
So if you think these change is meaningless in this gem, please just close this PR.  🙏 

Thanks for this useful tool!

---

I checked `bundle exec rspec` passed in following environments.

* ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-darwin20]
* ruby 2.5.8p224 (2020-03-31 revision 67882) [x86_64-linux] # On docker `rubylang/ruby:2.5.8-bionic`, needs https://github.com/x-motemen/git-pr-release/pull/58
* ruby 2.4.9p362 (2019-10-02 revision 67824) [x86_64-linux]  # On docker `rubylang/ruby:2.4.9-bionic` , needs https://github.com/x-motemen/git-pr-release/pull/58