### PR TITLE
Add sleep because the search is repeated for the number of commits

### DIFF
--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -125,6 +125,7 @@ module Git
         def fetch_merged_pr_numbers_from_github
           git(:log, '--pretty=format:%H', "origin/#{production_branch}..origin/#{staging_branch}").map(&:chomp).map do |sha1|
             client.search_issues("repo:#{repository} is:pr is:closed #{sha1}")[:items].map(&:number)
+            sleep 1
           end.flatten
         end
 


### PR DESCRIPTION
ref: #60 