### PR TITLE
fix wrong pr number due to sleep

### DIFF
--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -124,8 +124,8 @@ module Git
 
         def fetch_merged_pr_numbers_from_github
           git(:log, '--pretty=format:%H', "origin/#{production_branch}..origin/#{staging_branch}").map(&:chomp).map do |sha1|
-            client.search_issues("repo:#{repository} is:pr is:closed #{sha1}")[:items].map(&:number)
             sleep 1
+            client.search_issues("repo:#{repository} is:pr is:closed #{sha1}")[:items].map(&:number)
           end.flatten
         end
 


### PR DESCRIPTION
Hi,

It seems that when the squash option is used, the PR numbers all return `1`.
It has been occurring since #61 .
It seems to be because the return value of `sleep 1` is used in generating the array of PR numbers.

I was not able to add any test code, but I did confirm that the return value of the array map changes.

```ruby
irb(main):005:0> Array[1, 2, 3].map do |x|
irb(main):006:1* x
irb(main):007:1> sleep 1
irb(main):008:1> end
=> [1, 1, 1]
irb(main):009:0> Array[1, 2, 3].map do |x|
irb(main):010:1* sleep 1
irb(main):011:1> x
irb(main):012:1> end
=> [1, 2, 3]
```