### PR TITLE
Exclude titles from checklist items

### DIFF
--- a/lib/git/pr/release/pull_request.rb
+++ b/lib/git/pr/release/pull_request.rb
@@ -11,7 +11,7 @@ module Git
         end
 
         def to_checklist_item
-          "- [ ] ##{pr.number} #{pr.title}" + mention
+          "- [ ] ##{pr.number}" + mention
         end
 
         def html_link


### PR DESCRIPTION
This is because GitHub has been updated to automatically render the title of the Pull Request URL in the list item.

Close https://github.com/x-motemen/git-pr-release/issues/65