### PR TITLE
Add nil check for release_pr.body

### DIFF
--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -176,7 +176,7 @@ module Git
 
         def build_and_merge_pr_title_and_body(release_pr, merged_prs, changed_files)
           # release_pr is nil when dry_run && create_mode
-          old_body = release_pr ? release_pr.body : ""
+          old_body = (release_pr && release_pr.body != nil) ? release_pr.body : ""
           pr_title, new_body = build_pr_title_and_body(release_pr, merged_prs, changed_files, template_path)
 
           [pr_title, merge_pr_body(old_body, new_body)]


### PR DESCRIPTION
## Why

Fixed: https://github.com/x-motemen/git-pr-release/issues/67

I created a sample Pull Request what body is empty, and confirmed that returns nil with the sample code below.

This issue caused by GitHub API response is changed, but I could not confirmed this GitHub API changes is temporary or not.

sample pull request: 
https://github.com/w1mvy/git-pr-release/pull/1

```
(*'-') < cat sample.rb                                                                                   [~/go/src/github.com/w1mvy/sample-gh]
require "octokit"

client = Octokit::Client.new(:access_token => 'my-token')
pr = client.pull_request("w1mvy/git-pr-release", 1)

if pr.body == ''
  puts "empty"
elsif pr.body == nil
  puts "nil"
end

(*'-') < bundle exec ruby sample.rb                                                                      [~/go/src/github.com/w1mvy/sample-gh]
nil
```

## How

Add `nil` check to `release_pr.body`