### PR TITLE
remove duplicated PR entries at squash

### DIFF
--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -87,7 +87,7 @@ module Git
 
           merged_pull_request_numbers = @squashed ? fetch_merged_pr_numbers_from_github : fetch_merged_pr_numbers_from_git_remote
 
-          merged_prs = merged_pull_request_numbers.sort.map do |nr|
+          merged_prs = merged_pull_request_numbers.uniq.sort.map do |nr|
             pr = client.pull_request repository, nr
             say "To be released: ##{pr.number} #{pr.title}", :notice
             pr


### PR DESCRIPTION
# Problem

When executing `git-pr-release --squashed` option, each sha1 diff of staging and production is mapped to "To be Released" entry at the generated PR.  This results in duplicated entries if several sha1s belonged to single PR.

# Solution

`uniq` the pr numbers and remove duplicates.