### PR TITLE
[Spec] Fix spec for build_pr_title_and_body

### DIFF
--- a/spec/git/pr/release_spec.rb
+++ b/spec/git/pr/release_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Git::Pr::Release do
         pr_title, new_body = build_pr_title_and_body(@release_pr, @merged_prs, @changed_files, nil)
         expect(pr_title).to eq "Release 2019-02-20 22:58:35 +0900"
         expect(new_body).to eq <<~MARKDOWN
-          - [ ] #3 Provides a creating release pull-request object for template @hakobe
-          - [ ] #6 Support two factor auth @ninjinkun
+          - [ ] #3 @hakobe
+          - [ ] #6 @ninjinkun
         MARKDOWN
       }
     end


### PR DESCRIPTION
I resolved fail test in rspec.
related https://github.com/x-motemen/git-pr-release/issues/65

```
$ bundle exec rspec

...

Failures:

  1) Git::Pr::Release#build_pr_title_and_body without template_path is expected to eq "- [ ] #3 Provides a creating release pull-request object for template @hakobe\n- [ ] #6 Support two factor auth @ninjinkun\n"
     Failure/Error:
       expect(new_body).to eq <<~MARKDOWN
         - [ ] #3 Provides a creating release pull-request object for template @hakobe
         - [ ] #6 Support two factor auth @ninjinkun
       MARKDOWN

       expected: "- [ ] #3 Provides a creating release pull-request object for template @hakobe\n- [ ] #6 Support two factor auth @ninjinkun\n"
            got: "- [ ] #3 @hakobe\n- [ ] #6 @ninjinkun\n"

       (compared using ==)

       Diff:
       @@ -1,3 +1,3 @@
       -- [ ] #3 Provides a creating release pull-request object for template @hakobe
       -- [ ] #6 Support two factor auth @ninjinkun
       +- [ ] #3 @hakobe
       +- [ ] #6 @ninjinkun

     # ./spec/git/pr/release_spec.rb:26:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:25:in `block (2 levels) in <top (required)>'

Finished in 0.66679 seconds (files took 0.5231 seconds to load)
31 examples, 1 failure

Failed examples:

rspec ./spec/git/pr/release_spec.rb:23 # Git::Pr::Release#build_pr_title_and_body without template_path is expected to eq "- [ ] #3 Provides a creating release pull-request object for template @hakobe\n- [ ] #6 Support two factor auth @ninjinkun\n"

Randomized with seed 47878
```