### PR TITLE
Use `YAML.unsafe_load_file` instead of `YAML.load_file`

### DIFF
--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe Git::Pr::Release::CLI do
           conn.builder.handlers.delete(Faraday::Adapter::NetHttp)
           conn.adapter(:test, Faraday::Adapter::Test::Stubs.new)
         end
-        pr_3 = Sawyer::Resource.new(agent, YAML.load_file(file_fixture("pr_3.yml")))
-        pr_4 = Sawyer::Resource.new(agent, YAML.load_file(file_fixture("pr_4.yml")))
+        pr_3 = Sawyer::Resource.new(agent, load_yaml("pr_3.yml"))
+        pr_4 = Sawyer::Resource.new(agent, load_yaml("pr_4.yml"))
         [pr_3, pr_4]
       }
       it {
@@ -219,8 +219,8 @@ RSpec.describe Git::Pr::Release::CLI do
       }
 
       client = double(Octokit::Client)
-      @pr_3 = Sawyer::Resource.new(agent, YAML.load_file(file_fixture("pr_3.yml")))
-      @pr_4 = Sawyer::Resource.new(agent, YAML.load_file(file_fixture("pr_4.yml")))
+      @pr_3 = Sawyer::Resource.new(agent, load_yaml("pr_3.yml"))
+      @pr_4 = Sawyer::Resource.new(agent, load_yaml("pr_4.yml"))
       expect(client).to receive(:pull_request).with("motemen/git-pr-release", 3) { @pr_3 }
       expect(client).to receive(:pull_request).with("motemen/git-pr-release", 4) { @pr_4 }
       allow(@cli).to receive(:client).with(no_args) { client }
@@ -241,8 +241,8 @@ RSpec.describe Git::Pr::Release::CLI do
       end
 
       @merged_prs = [
-        Sawyer::Resource.new(@agent, YAML.load_file(file_fixture("pr_3.yml"))),
-        Sawyer::Resource.new(@agent, YAML.load_file(file_fixture("pr_4.yml"))),
+        Sawyer::Resource.new(@agent, load_yaml("pr_3.yml")),
+        Sawyer::Resource.new(@agent, load_yaml("pr_4.yml")),
       ]
 
       allow(@cli).to receive(:detect_existing_release_pr) { existing_release_pr }
@@ -261,7 +261,7 @@ RSpec.describe Git::Pr::Release::CLI do
 
     context "When create_mode" do
       before {
-        @created_pr = Sawyer::Resource.new(@agent, YAML.load_file(file_fixture("pr_1.yml")))
+        @created_pr = Sawyer::Resource.new(@agent, load_yaml("pr_1.yml"))
         allow(@cli).to receive(:prepare_release_pr) { @created_pr }
       }
 
@@ -301,7 +301,7 @@ RSpec.describe Git::Pr::Release::CLI do
 
     context "When dry_run with create_mode" do
       before {
-        @created_pr = Sawyer::Resource.new(@agent, YAML.load_file(file_fixture("pr_1.yml")))
+        @created_pr = Sawyer::Resource.new(@agent, load_yaml("pr_1.yml"))
         allow(@cli).to receive(:prepare_release_pr) { @created_pr }
 
         @cli.instance_variable_set(:@dry_run, true)

--- a/spec/git/pr/release_spec.rb
+++ b/spec/git/pr/release_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe Git::Pr::Release do
       conn.builder.handlers.delete(Faraday::Adapter::NetHttp)
       conn.adapter :test, @stubs
     end
-    @release_pr = Sawyer::Resource.new(@agent, YAML.load_file(file_fixture("pr_1.yml")))
+    @release_pr = Sawyer::Resource.new(@agent, load_yaml("pr_1.yml"))
     @merged_prs = [
-      Sawyer::Resource.new(@agent, YAML.load_file(file_fixture("pr_3.yml"))),
-      Sawyer::Resource.new(@agent, YAML.load_file(file_fixture("pr_6.yml"))),
+      Sawyer::Resource.new(@agent, load_yaml("pr_3.yml")),
+      Sawyer::Resource.new(@agent, load_yaml("pr_6.yml")),
     ]
     @changed_files = [
-      Sawyer::Resource.new(@agent, YAML.load_file(file_fixture("pr_1_files.yml"))),
+      Sawyer::Resource.new(@agent, load_yaml("pr_1_files.yml")),
     ]
   end
 

--- a/spec/support/file_fixture_support.rb
+++ b/spec/support/file_fixture_support.rb
@@ -1,4 +1,12 @@
 module FileFixtureSupport
+  def load_yaml(fixture_name)
+    if RUBY_VERSION >= '3.0'
+      YAML.unsafe_load_file(file_fixture(fixture_name))
+    else
+      YAML.load_file(file_fixture(fixture_name))
+    end
+  end
+
   def file_fixture(fixture_name)
     file_fixture_path = RSpec.configuration.file_fixture_path
     path = Pathname.new(File.join(file_fixture_path, fixture_name))


### PR DESCRIPTION
## Issue

closes https://github.com/x-motemen/git-pr-release/issues/72

## Change

Ruby 3.1.0 might include a breaking change using Psych v4 as default.

ref: https://bugs.ruby-lang.org/issues/17866

According to the issue on `bugs.ruby-lang.org`, it's not decided yet that Ruby 3.1.0 includes the change.
But even if Ruby 3.1.0 doesn't ship the change, it's nice to use `unsafe_load_file` explicitly for further breaking change, I think.

## Testing

Tests passed on CI.

https://github.com/x-motemen/git-pr-release/runs/4560196751?check_suite_focus=true