### PR TITLE
Add option "ssl_no_verify" to skip verifying ssl certificate

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ You can specify this value by `GIT_PR_RELEASE_MENTION` environment variable.
 
 If not specified, the mention will be the PR assignee
 
+## `pr-release.ssl_no_verify`
+
+Whether to verify SSL certificate or not.
+Accepted values: `true` | `false`
+
+This option might be useful when self-hosted GitHub enterprise server is using self-signed certificate.
+
+You can specify this value by `GIT_PR_RELEASE_SSL_NO_VERIFY` to `1`.
+
+If not specified, verify SSL certificate always.
 
 Errors and exit statuses
 ------------------------

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -58,9 +58,13 @@ module Git
         def configure
           host, @repository, scheme = host_and_repository_and_scheme
 
-          if host && scheme == 'https'
-            ssl_no_verify = %w[true 1].include? ENV.fetch('GIT_PR_RELEASE_SSL_NO_VERIFY') { git_config('ssl_no_verify') }
-            OpenSSL::SSL.const_set :VERIFY_PEER, OpenSSL::SSL::VERIFY_NONE if ssl_no_verify
+          if host
+            if host != 'github.com' && scheme == 'https' # GitHub Enterprise
+              ssl_no_verify = %w[true 1].include? ENV.fetch('GIT_PR_RELEASE_SSL_NO_VERIFY') { git_config('ssl_no_verify') }
+              if ssl_no_verify
+                OpenSSL::SSL.const_set :VERIFY_PEER, OpenSSL::SSL::VERIFY_NONE
+              end
+            end
 
             Octokit.configure do |c|
               c.api_endpoint = "#{scheme}://#{host}/api/v3"

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -58,9 +58,9 @@ module Git
         def configure
           host, @repository, scheme = host_and_repository_and_scheme
 
-          if host
-            # GitHub:Enterprise
-            OpenSSL::SSL.const_set :VERIFY_PEER, OpenSSL::SSL::VERIFY_NONE # XXX
+          if host && scheme == 'https'
+            ssl_no_verify = %w[true 1].include? ENV.fetch('GIT_PR_RELEASE_SSL_NO_VERIFY') { git_config('ssl_no_verify') }
+            OpenSSL::SSL.const_set :VERIFY_PEER, OpenSSL::SSL::VERIFY_NONE if ssl_no_verify
 
             Octokit.configure do |c|
               c.api_endpoint = "#{scheme}://#{host}/api/v3"


### PR DESCRIPTION
closes #15

- Verify SSL certificate default
- Add `pr-release.ssl_no_verify` option to skip verifying SSL certificate
  - Also Env `GIT_PR_RELEASE_SSL_NO_VERIFY` works