### PR TITLE
add an argument to to_checklist_item to print pr title

### DIFF
--- a/lib/git/pr/release/pull_request.rb
+++ b/lib/git/pr/release/pull_request.rb
@@ -10,8 +10,12 @@ module Git
           @pr = pr
         end
 
-        def to_checklist_item
-          "- [ ] ##{pr.number}" + mention
+        def to_checklist_item(print_title = false)
+          if print_title
+            "- [ ] ##{pr.number} #{pr.title}" + mention
+          else
+            "- [ ] ##{pr.number}" + mention
+          end
         end
 
         def html_link


### PR DESCRIPTION
cf. #66

Add optional argument to `PullRequest#to_checklist_item` to print title of pull request.
It still isn't printed In default.

----

I know GitHub's markdown renders the title and state of issue/pullreq automatically:

> If you reference an issue, pull request, or discussion in a list, the reference will unfurl to show the title and state instead.
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#issues-and-pull-requests

However, this feature is disabled in GitHub Enterprise Server for now (2022-03-01).

As proof of it, there is no description about automatically printed the title and state in doc.
https://docs.github.com/en/enterprise-server@3.4/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#issues-and-pull-requests