### PR TITLE
fix forbidden git config name (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can specify this value by `GIT_PR_RELEASE_MENTION` environment variable.
 
 If not specified, the mention will be the PR assignee
 
-## `pr-release.ssl_no_verify`
+### `pr-release.ssl-no-verify`
 
 Whether to verify SSL certificate or not.
 Accepted values: `true` | `false`

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -59,8 +59,8 @@ module Git
           host, @repository, scheme = host_and_repository_and_scheme
 
           if host
-            if host != 'github.com' && scheme == 'https' # GitHub Enterprise
-              ssl_no_verify = %w[true 1].include? ENV.fetch('GIT_PR_RELEASE_SSL_NO_VERIFY') { git_config('ssl_no_verify') }
+            if scheme == 'https' # GitHub Enterprise
+              ssl_no_verify = %w[true 1].include? ENV.fetch('GIT_PR_RELEASE_SSL_NO_VERIFY') { git_config('ssl-no-verify') }
               if ssl_no_verify
                 OpenSSL::SSL.const_set :VERIFY_PEER, OpenSSL::SSL::VERIFY_NONE
               end


### PR DESCRIPTION
closes #80 

#77 introduces new configuration `ssl_no_verify` in `git config`.
But git config does not allow to use underscore.

```console
$ git config pr-release.foo_bar
error: invalid key: pr-release.foo_bar
```

>  The variable names are case-insensitive, allow only alphanumeric characters and -, and must start with an alphabetic character. 
https://git-scm.com/docs/git-config#_configuration_file

To fix it, rename `ssl_no_verify` to `ssl-no-verify`.