### PR TITLE
Fix CI (uninitialized constant Sawyer)

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,9 @@ RSpec.configure do |config|
   config.after do
     Timecop.return
   end
+
+  # Trigger Autoload
+  Octokit::Client
 end
 
 Dir[File.expand_path("support/**/*.rb", __dir__)].each {|f| require f }


### PR DESCRIPTION
octokit v4.23.0 changes to load Octokit::Client with autoload.