### PR TITLE
delegate to @pr when method_missing in PullRequest

### DIFF
--- a/lib/git/pr/release/pull_request.rb
+++ b/lib/git/pr/release/pull_request.rb
@@ -41,8 +41,8 @@ module Git
           @mention_type ||= (ENV.fetch('GIT_PR_RELEASE_MENTION') { git_config('mention') } || 'default')
         end
 
-        def method_missing(name, *args)
-          @pr.public_send name, *args
+        def method_missing(name, *args, &block)
+          @pr.public_send name, *args, &block
         end
 
         def respond_to_missing?(name, include_private = false)

--- a/lib/git/pr/release/pull_request.rb
+++ b/lib/git/pr/release/pull_request.rb
@@ -44,6 +44,10 @@ module Git
         def method_missing(name, *args)
           @pr.send name, *args
         end
+
+        def respond_to_missing?(name, include_private = false)
+          @pr.respond_to?(name, include_private)
+        end
       end
     end
   end

--- a/lib/git/pr/release/pull_request.rb
+++ b/lib/git/pr/release/pull_request.rb
@@ -40,6 +40,10 @@ module Git
         def self.mention_type
           @mention_type ||= (ENV.fetch('GIT_PR_RELEASE_MENTION') { git_config('mention') } || 'default')
         end
+
+        def method_missing(name, *args)
+          @pr.send name, *args
+        end
       end
     end
   end

--- a/lib/git/pr/release/pull_request.rb
+++ b/lib/git/pr/release/pull_request.rb
@@ -42,7 +42,7 @@ module Git
         end
 
         def method_missing(name, *args)
-          @pr.send name, *args
+          @pr.public_send name, *args
         end
 
         def respond_to_missing?(name, include_private = false)


### PR DESCRIPTION
It is stressful to call out pr over and over when writing our templates as follows.

```erb
<% pull_requests.each do |pr| -%>
- #<%=  pr.pr.number %>
<% end -%>
```

So I resolved to use method_missing to delegate, even though it is rough.

I'm not a Ruby person, so I don't know if this is a good way. However, git-pr-release is just a tool, so I think having an easy interface like this is not a bad idea.