### PR TITLE
unshallow if a shallow repository

### DIFF
--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -87,6 +87,10 @@ module Git
         end
 
         def fetch_merged_prs
+          bool = git(:'rev-parse', '--is-shallow-repository').first.chomp
+          if bool == 'true'
+            git(:fetch, '--unshallow')
+          end
           git :remote, 'update', 'origin' unless @no_fetch
 
           merged_pull_request_numbers = fetch_merged_pr_numbers_from_git_remote

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -194,6 +194,7 @@ RSpec.describe Git::Pr::Release::CLI do
         conn.adapter(:test, Faraday::Adapter::Test::Stubs.new)
       end
 
+      expect(@cli).to receive(:git).with(:'rev-parse', "--is-shallow-repository") { ["false\n"] }
       expect(@cli).to receive(:git).with(:remote, "update", "origin") {
         []
       }


### PR DESCRIPTION
git-pr-release requires git history. However, in many CI services in recent years, the shallow clone is used by default for speed. e.g., https://github.com/actions/checkout

It requires users to write additional settings such as `fetch-depth: 0`, which is a pitfall for beginners.

To make it easier to use, I add behavior to determine if a repository is a shallow repository and, if so, unshallow it.

It may be controversial whether this behavior is also applied when `--no-fetch` is specified. Still, I added this behavior uniformly since git-pr-release does not work correctly with a shallow clone.

`git fetch --unshallow` is available git 1.8.3 or later, and `git rev-parse --is-shallow-repository` is also 2.15. These are old enough, and in recent years, users have been using the newer git client for security reasons, so I do not check the git version compatibility.