### PR TITLE
Add overwrite-description option

### DIFF
--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -34,6 +34,9 @@ module Git
             opts.on('--squashed', 'Handle squash merged PRs') do |v|
               @squashed = v
             end
+            opts.on('--overwrite-description', 'Force overwrite PR description') do |v|
+              @overwrite_description = v
+            end
           end.parse!
 
           ### Set up configuration
@@ -195,7 +198,11 @@ module Git
             changed_files = pull_request_files(release_pr)
           end
 
-          pr_title, pr_body = build_and_merge_pr_title_and_body(release_pr, merged_prs, changed_files)
+          pr_title, pr_body = if @overwrite_description
+                                build_pr_title_and_body(release_pr, merged_prs, changed_files, template_path)
+                              else
+                                build_and_merge_pr_title_and_body(release_pr, merged_prs, changed_files)
+                              end
 
           if @dry_run
             say 'Dry-run. Not updating PR', :info

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -320,6 +320,32 @@ RSpec.describe Git::Pr::Release::CLI do
         expect(@cli).not_to have_received(:update_release_pr).with(@created_pr, @pr_title, @pr_body)
       }
     end
+
+    context "When overwrite_description" do
+      before {
+        @cli.instance_variable_set(:@overwrite_description, true)
+        @new_pr_title = "2022-08-17 12:34:58 +0900"
+        @new_pr_body = <<~BODY.chomp
+          - [ ] #3 @hakobe
+          - [ ] #4 @hakobe
+        BODY
+        allow(@cli).to receive(:build_pr_title_and_body) {
+          [@new_pr_title, @new_pr_body]
+        }
+      }
+
+      let(:existing_release_pr) { double(
+        number: 1023,
+        rels: { html: double(href: "https://github.com/motemen/git-pr-release/pull/1023") },
+      )}
+
+      it {
+        subject
+
+        expect(@cli).not_to have_received(:build_and_merge_pr_title_and_body)
+        expect(@cli).to have_received(:update_release_pr).with(existing_release_pr, @new_pr_title, @new_pr_body)
+      }
+    end
   end
 
   describe "#prepare_release_pr" do


### PR DESCRIPTION
Merging PR's description create a lot of duplication when customizing templates.
Especially if I'm using checkboxes for work procedure manual instead of a list of PRs.