### PR TITLE
Aggregate labels from prs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ You can specify this value by `GIT_PR_RELEASE_LABELS` environment variable.
 
 If not specified, any labels will not be added for PRs.
 
+### `pr-release.aggregate_labels`
+
+If it is `true`, `git-pr-release` aggregates labels from merged pull requests and add them to a created pull request.
+
+If also `pr-release.labels` has values, `git-pr-release` merges aggregates labels and labels given by `pr-release.labels`.
+
+You can specify this value by `GIT_PR_RELEASE_AGGREGATE_LABELS` environment variable.
+
+Default value: `false`.
+
+If not specified, it doesn't aggregate labels from merged pull requests.
+
 ### `pr-release.mention`
 
 The name that is listed next to each PR title.

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -6,7 +6,7 @@ module Git
     module Release
       class CLI
         include Git::Pr::Release::Util
-        attr_reader :repository, :production_branch, :staging_branch, :template_path, :labels
+        attr_reader :repository, :production_branch, :staging_branch, :template_path, :labels, :aggregate_labels
 
         def self.start
           result = self.new.start
@@ -78,6 +78,7 @@ module Git
           @production_branch = ENV.fetch('GIT_PR_RELEASE_BRANCH_PRODUCTION') { git_config('branch.production') } || 'master'
           @staging_branch    = ENV.fetch('GIT_PR_RELEASE_BRANCH_STAGING') { git_config('branch.staging') }       || 'staging'
           @template_path     = ENV.fetch('GIT_PR_RELEASE_TEMPLATE') { git_config('template') }
+          @aggregate_labels   = ENV.fetch('GIT_PR_RELEASE_AGGREGATE_LABELS') { git_config('aggregate_labels') } == 'true'
 
           _labels = ENV.fetch('GIT_PR_RELEASE_LABELS') { git_config('labels') }
           @labels = _labels && _labels.split(/\s*,\s*/) || []
@@ -86,7 +87,8 @@ module Git
           say "Production branch: #{production_branch}", :debug
           say "Staging branch:    #{staging_branch}", :debug
           say "Template path:     #{template_path}", :debug
-          say "Labels             #{labels}", :debug
+          say "Labels:            #{labels}#{aggregate_labels ? ' + labels on merged PRs' : ''}", :debug
+          say "Aggregate Labels:  #{aggregate_labels}", :debug
         end
 
         def fetch_merged_prs
@@ -105,6 +107,13 @@ module Git
             pr = client.pull_request repository, nr
             say "To be released: ##{pr.number} #{pr.title}", :notice
             pr
+          end
+
+          if @aggregate_labels
+            merged_prs_labels = merged_prs.flat_map do |pr|
+              pr.labels.map(&:name)
+            end
+            @labels = (labels + merged_prs_labels).uniq
           end
 
           merged_prs

--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -78,7 +78,7 @@ module Git
           @production_branch = ENV.fetch('GIT_PR_RELEASE_BRANCH_PRODUCTION') { git_config('branch.production') } || 'master'
           @staging_branch    = ENV.fetch('GIT_PR_RELEASE_BRANCH_STAGING') { git_config('branch.staging') }       || 'staging'
           @template_path     = ENV.fetch('GIT_PR_RELEASE_TEMPLATE') { git_config('template') }
-          @aggregate_labels   = ENV.fetch('GIT_PR_RELEASE_AGGREGATE_LABELS') { git_config('aggregate_labels') } == 'true'
+          @aggregate_labels   = ENV.fetch('GIT_PR_RELEASE_AGGREGATE_LABELS') { git_config('aggregate-labels') } == 'true'
 
           _labels = ENV.fetch('GIT_PR_RELEASE_LABELS') { git_config('labels') }
           @labels = _labels && _labels.split(/\s*,\s*/) || []

--- a/spec/fixtures/file/pr_3.yml
+++ b/spec/fixtures/file/pr_3.yml
@@ -37,12 +37,19 @@
 :closed_at: 2014-03-13 11:42:18.000000000 Z
 :merged_at: 2014-03-13 11:42:18.000000000 Z
 :merge_commit_sha: 2ff5c670d9bebde490a6651f185ecba6cb09b48d
-:assignee: 
+:assignee:
 :assignees: []
 :requested_reviewers: []
 :requested_teams: []
-:labels: []
-:milestone: 
+:labels:
+  - :id: 208045946,
+    :node_id: "MDU6TGFiZWwyMDgwNDU5NDY="
+    :url: "https://api.github.com/repos/octocat/Hello-World/labels/bug"
+    :name: "bug"
+    :description: "Something isn't working"
+    :color: "f29513"
+    :default: true
+:milestone:
 :commits_url: https://api.github.com/repos/motemen/git-pr-release/pulls/3/commits
 :review_comments_url: https://api.github.com/repos/motemen/git-pr-release/pulls/3/comments
 :review_comment_url: https://api.github.com/repos/motemen/git-pr-release/pulls/comments{/number}
@@ -155,10 +162,10 @@
     :has_wiki: true
     :has_pages: false
     :forks_count: 0
-    :mirror_url: 
+    :mirror_url:
     :archived: false
     :open_issues_count: 0
-    :license: 
+    :license:
     :forks: 0
     :open_issues: 0
     :watchers: 0
@@ -269,7 +276,7 @@
     :has_wiki: true
     :has_pages: false
     :forks_count: 28
-    :mirror_url: 
+    :mirror_url:
     :archived: false
     :open_issues_count: 6
     :license:
@@ -301,8 +308,8 @@
     :href: https://api.github.com/repos/motemen/git-pr-release/statuses/5c977a1827387ac7b7a85c7b827ee119165f1823
 :author_association: COLLABORATOR
 :merged: true
-:mergeable: 
-:rebaseable: 
+:mergeable:
+:rebaseable:
 :mergeable_state: unknown
 :merged_by:
   :login: motemen

--- a/spec/fixtures/file/pr_4.yml
+++ b/spec/fixtures/file/pr_4.yml
@@ -35,12 +35,19 @@
 :closed_at: 2014-03-26 10:49:03.000000000 Z
 :merged_at: 2014-03-26 10:49:03.000000000 Z
 :merge_commit_sha: 19dd4309bfac0b0358e7e87f48a007ef54634140
-:assignee: 
+:assignee:
 :assignees: []
 :requested_reviewers: []
 :requested_teams: []
-:labels: []
-:milestone: 
+:labels:
+  - :id: 208045946,
+    :node_id: "MDU6TGFiZWwyMDgwNDU5NDY="
+    :url: "https://api.github.com/repos/octocat/Hello-World/labels/bug"
+    :name: "enhancement"
+    :description: "Something isn't working"
+    :color: "f29513"
+    :default: true
+:milestone:
 :commits_url: https://api.github.com/repos/motemen/git-pr-release/pulls/4/commits
 :review_comments_url: https://api.github.com/repos/motemen/git-pr-release/pulls/4/comments
 :review_comment_url: https://api.github.com/repos/motemen/git-pr-release/pulls/comments{/number}
@@ -152,7 +159,7 @@
     :has_wiki: true
     :has_pages: false
     :forks_count: 28
-    :mirror_url: 
+    :mirror_url:
     :archived: false
     :open_issues_count: 6
     :license:
@@ -271,7 +278,7 @@
     :has_wiki: true
     :has_pages: false
     :forks_count: 28
-    :mirror_url: 
+    :mirror_url:
     :archived: false
     :open_issues_count: 6
     :license:
@@ -303,8 +310,8 @@
     :href: https://api.github.com/repos/motemen/git-pr-release/statuses/42bd43b80c973c8f348df3521745201be05bf194
 :author_association: COLLABORATOR
 :merged: true
-:mergeable: 
-:rebaseable: 
+:mergeable:
+:rebaseable:
 :mergeable_state: unknown
 :merged_by:
   :login: motemen


### PR DESCRIPTION
@onk @motemen

This is a revival of #56 originally done by @ohbarye, who kindly [allowed](https://github.com/x-motemen/git-pr-release/pull/56#issuecomment-1936795676) me to take over the work. [The only change I made](https://github.com/x-motemen/git-pr-release/commit/c2795dcb79aeafd692bd2c8d3b385448b146baa3) is changing the config name from `aggregate_labels` to `aggregate-labels` because `git config` returns an error when the config name contains underscores.

## Issue

Closes #54

## Changes

As described in #54, this change adds a feature to add labels assigned to merged pull requests.

- Add `pr-release.aggregate-labels` config (or `GIT_RELEASE_PR_AGGREGATE_LABELS` environment variable). It accepts a boolean-ish value, "true" or anything. Only when it is "true", `git-release-pr` aggregates labels from merged pull requests.
- When `pr-release.labels` is given at the same time, merge them.  For example, when `pr-release.labels=foo,bar` and aggregated labels are "baz", labels would be ["foo", "bar", "baz"].

## Testing

Confirmed `git-pr-release` with this change created [a release pull request](https://github.com/masaru-iritani/git-pr-release/pull/2) with a label assigned to [a merged pull request](https://github.com/masaru-iritani/git-pr-release/pull/1).

```
> DEBUG=true GIT_PR_RELEASE_AGGREGATE_LABELS=true GIT_PR_RELEASE_BRANCH_PRODUCTION=production GIT_PR_RELEASE_BRANCH_STAGING=staging bundle exec ruby ./exe/git-pr-release
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
Executing `git config remote.origin.url`
Executing `git config -f .git-pr-release pr-release.template`
Executing `git config pr-release.template`
Executing `git config -f .git-pr-release pr-release.labels`
Executing `git config pr-release.labels`
Repository:        masaru-iritani/git-pr-release
Production branch: production
Staging branch:    staging
Template path:     
Labels:            [] + labels on merged PRs
Aggregate Labels:  true
Executing `git rev-parse --is-shallow-repository`
Executing `git remote update origin`
Executing `git log --merges --pretty=format:%P origin/production..origin/staging`
Executing `git ls-remote origin refs/pull/*/head`
Executing `git merge-base 7b52c76689f00bef5c77950534ad11a17908c2de origin/production`
Executing `git config -f .git-pr-release pr-release.token`
Executing `git config pr-release.token`
To be released: #1 Update README.md
Searching for existing release pull requests...
Executing `git config remote.origin.url`
Executing `git config -f .git-pr-release pr-release.mention`
Executing `git config pr-release.mention`
diff: #<Diff::LCS::ContextChange: ["+", [0, nil], [0, "- [ ] #1 @masaru-iritani"]]>
Use line as is: - [ ] #1 @masaru-iritani
Pull request body:
- [ ] #1 @masaru-iritani
Updated pull request: https://github.com/masaru-iritani/git-pr-release/pull/2
```

## Review Points

- Is `aggregate-labels` the best name among other ideas such as `reuse-labels` and `summarize-labels`, etc.?
- Should `aggregate-labels` be given as a command line argument, not environment variable or `git config`, like other boolean values such as `--dry-run` and `--no-fecth`? (It depends on this gem's command line design.)