### PR TITLE
add draft option

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,15 @@ You can specify this value by `GIT_PR_RELEASE_SSL_NO_VERIFY` to `1`.
 
 If not specified, verify SSL certificate always.
 
+### `pr-release.draft`
+
+The pull request is draft no not.
+Accepted values: `true` | `false`
+
+You can specify this value by `GIT_PR_RELEASE_DRAFT` environment variable.
+
+Default value: `false`.
+
 ## Errors and exit statuses
 
 ### No pull requests to be released

--- a/lib/git/pr/release/util.rb
+++ b/lib/git/pr/release/util.rb
@@ -199,6 +199,24 @@ ERB
 
           auth
         end
+
+        def to_boolean(flag)
+          case flag
+          when TrueClass, FalseClass
+            flag
+          when String
+            flag = flag.downcase
+            if flag == 'true'
+              true
+            elsif flag == 'false'
+              false
+            else
+              nil
+            end
+          else
+            nil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Hello,  @onk @motemen .

Thank you for create great gem. I and our company always use.

## Issue
Closes https://github.com/x-motemen/git-pr-release/issues/93

## Changes

I added create draft pull request feature.

- Add `pr-release.draft` config ( `GIT_PR_RELEASE_DRAFT` )
	-  default is `false`
	-  if the above config expect `true` or `false`, raise error.

## Image

<img width="932" alt="image" src="https://github.com/x-motemen/git-pr-release/assets/995846/3f127b0a-883a-461a-92c6-9062462cd653">