### PR TITLE
Allow big bang release PR

### DIFF
--- a/lib/git/pr/release/util.rb
+++ b/lib/git/pr/release/util.rb
@@ -157,7 +157,7 @@ ERB
           merged_body = pr_body_lines.join("\n")
           check_status.each { |issue_number, check_value|
             say "Update pull-request checkbox \##{issue_number} to #{check_value}.", :trace
-            merged_body.gsub! /^- \[ \] \##{issue_number}\s/, "- [#{check_value}] \##{issue_number}\s"
+            merged_body.gsub! /^- \[ \] \##{issue_number}\b/, "- [#{check_value}] \##{issue_number}"
           }
 
           merged_body

--- a/lib/git/pr/release/util.rb
+++ b/lib/git/pr/release/util.rb
@@ -157,7 +157,7 @@ ERB
           merged_body = pr_body_lines.join("\n")
           check_status.each { |issue_number, check_value|
             say "Update pull-request checkbox \##{issue_number} to #{check_value}.", :trace
-            merged_body.gsub! /^- \[ \] \##{issue_number}/, "- [#{check_value}] \##{issue_number}"
+            merged_body.gsub! /^- \[ \] \##{issue_number}\s/, "- [#{check_value}] \##{issue_number}\s"
           }
 
           merged_body

--- a/spec/git/pr/release_spec.rb
+++ b/spec/git/pr/release_spec.rb
@@ -63,14 +63,12 @@ RSpec.describe Git::Pr::Release do
           - [ ] #3 Provides a creating release pull-request object for template @hakobe
           - [ ] #4 use user who create PR if there is no assignee @hakobe
           - [ ] #6 Support two factor auth @ninjinkun
-          - [ ] #30 Extract logic from bin/git-pr-release @banyan
         NEW_BODY
 
         expect(actual).to eq <<~MARKDOWN.chomp
           - [x] #3 Provides a creating release pull-request object for template @hakobe
           - [ ] #4 use user who create PR if there is no assignee @hakobe
           - [ ] #6 Support two factor auth @ninjinkun
-          - [ ] #30 Extract logic from bin/git-pr-release @banyan
         MARKDOWN
       }
     end
@@ -89,6 +87,26 @@ RSpec.describe Git::Pr::Release do
           - [ ] #3 Provides a creating release pull-request object for template @hakobe
           - [x] #4 use user who create PR if there is no assignee @hakobe
           - [x] #6 Support two factor auth @ninjinkun
+        MARKDOWN
+      }
+    end
+    context "new pr added when the same numbers are included in a forward match" do
+      it {
+        actual = merge_pr_body(<<~OLD_BODY, <<~NEW_BODY)
+          - [x] #3 Provides a creating release pull-request object for template @hakobe
+          - [ ] #6 Support two factor auth @ninjinkun
+        OLD_BODY
+          - [ ] #3 Provides a creating release pull-request object for template @hakobe
+          - [ ] #4 use user who create PR if there is no assignee @hakobe
+          - [ ] #6 Support two factor auth @ninjinkun
+          - [ ] #30 Extract logic from bin/git-pr-release @banyan
+        NEW_BODY
+
+        expect(actual).to eq <<~MARKDOWN.chomp
+          - [x] #3 Provides a creating release pull-request object for template @hakobe
+          - [ ] #4 use user who create PR if there is no assignee @hakobe
+          - [ ] #6 Support two factor auth @ninjinkun
+          - [ ] #30 Extract logic from bin/git-pr-release @banyan
         MARKDOWN
       }
     end

--- a/spec/git/pr/release_spec.rb
+++ b/spec/git/pr/release_spec.rb
@@ -63,12 +63,14 @@ RSpec.describe Git::Pr::Release do
           - [ ] #3 Provides a creating release pull-request object for template @hakobe
           - [ ] #4 use user who create PR if there is no assignee @hakobe
           - [ ] #6 Support two factor auth @ninjinkun
+          - [ ] #30 Extract logic from bin/git-pr-release @banyan
         NEW_BODY
 
         expect(actual).to eq <<~MARKDOWN.chomp
           - [x] #3 Provides a creating release pull-request object for template @hakobe
           - [ ] #4 use user who create PR if there is no assignee @hakobe
           - [ ] #6 Support two factor auth @ninjinkun
+          - [ ] #30 Extract logic from bin/git-pr-release @banyan
         MARKDOWN
       }
     end


### PR DESCRIPTION
@onk @motemen
Hello,
I have discovered that unintended behavior occurs during the big bang release typically seen in the early stages of repository setup.

# Issue
Due to the checkbox state verification being based on a prefix match of the PR number, when multiple PRs are included, checkboxes may be unintentionally marked for PRs that weren't intended.
```
// Old Body
- [x] #3 Provides a creating release pull-request object for template @hakobe
- [ ] #6 Support two factor auth @ninjinkun

// New Body
- [ ] #3 Provides a creating release pull-request object for template @hakobe
- [ ] #6 Support two factor auth @ninjinkun
- [ ] #30 Extract logic from bin/git-pr-release @banyan

// Expected 
- [x] #3 Provides a creating release pull-request object for template @hakobe
- [ ] #6 Support two factor auth @ninjinkun
- [ ] #30 Extract logic from bin/git-pr-release @banyan

// Actual
- [x] #3 Provides a creating release pull-request object for template @hakobe
- [ ] #6 Support two factor auth @ninjinkun
- [x] #30 Extract logic from bin/git-pr-release @banyan
```

# Solution
Modify to check for the existence of a space after the PR number.