### PR TITLE
Consider url encode

### DIFF
--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -1,5 +1,6 @@
 require 'octokit'
 require 'optparse'
+require 'cgi'
 
 module Git
   module Pr
@@ -169,7 +170,7 @@ module Git
           shas.each do |sha|
             # Longer than 256 characters are not supported in the query.
             # ref. https://docs.github.com/en/rest/reference/search#limitations-on-query-length
-            if query.length + 1 + sha.length >= 256
+            if CGI.escape(query).length + 1 + sha.length >= 256
               pr_nums.concat(search_issue_numbers(query))
               query = query_base
             end


### PR DESCRIPTION
Colon and Slash will be encoded to %3A and %2F, so if the query has those characters, it will be overflowed. So it need to be considered