### PR TITLE
Enhance fetch_squash_merged_pr_numbers_from_github to Exclude Unmerged Closed Pull Requests 

### DIFF
--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -159,7 +159,7 @@ module Git
             "origin/#{production_branch}..origin/#{staging_branch}").map(&:chomp)
 
           pr_nums = []
-          query_base = "repo:#{repository} is:pr is:closed"
+          query_base = "repo:#{repository} is:pr is:merged"
           query = query_base
           # Make bulk requests with multiple SHAs of the maximum possible length.
           # If multiple SHAs are specified, the issue search API will treat it like an OR search,


### PR DESCRIPTION
The `fetch_squash_merged_pr_numbers_from_github` method currently includes pull requests that have been closed without being merged.
This leads to the retrieval of pull request numbers that are not part of the merged codebase, causing potential inaccuracies in processing.

### Changes Proposed

- Update the GitHub search query within the method from `is:closed` to `is:merged`.
- Ensure that only merged pull requests are fetched, excluding those that were merely closed without merging.

```ruby
# Original query includes all closed pull requests
query_base = "repo:#{repository} is:pr is:closed"

# Updated query to include only merged pull requests
query_base = "repo:#{repository} is:pr is:merged"
```

### Rationale

Using `is:merged` ensures that only pull requests that have been successfully merged are included. This change improves the accuracy of the retrieved data by excluding pull requests that were closed without merging.

### References

- [GitHub Search Documentation - Searching issues and pull requests](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests)