### PR TITLE
Retry search_issue_numbers until 3 times considering secondary rate limit error

### DIFF
--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -137,12 +137,22 @@ module Git
         end
 
         def search_issue_numbers(query)
-          sleep 1
-          say "search issues with query:#{query}", :debug
-          # Fortunately, we don't need to take care of the page count in response, because
-          # the default value of per_page is 30 and we can't specify more than 30 commits due to
-          # the length limit specification of the query string.
-          client.search_issues("#{query}")[:items].map(&:number)
+          try = 0
+          begin
+            try += 1
+            say "search issues with query:#{query}", :debug
+            # Fortunately, we don't need to take care of the page count in response, because
+            # the default value of per_page is 30 and we can't specify more than 30 commits due to
+            # the length limit specification of the query string.
+            client.search_issues("#{query}")[:items].map(&:number)
+          rescue
+            if try <= 3 # try 3 times considering Secondary rate limit
+              say "Failed to search issues. Retry after 30 seconds", :warn
+              sleep 30
+              retry
+            end
+            raise
+          end
         end
 
         def fetch_squash_merged_pr_numbers_from_github


### PR DESCRIPTION
# Overview

We are using this action, but approximately one out of every three runs encounters a GitHub Secondary Rate Limit, causing the Action to fail.

Below is fail example.

```
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
From https://github.com/my-vision-co-jp/our-vision-api
 * [new branch]      feature/add_column_graduation_year -> origin/feature/add_column_graduation_year
 * [new branch]      main       -> origin/main
/opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/octokit-8.1.0/lib/octokit/response/raise_error.rb:14:in `on_complete': GET https://api.github.com/search/issues?q=repo%3Amy-vision-co-jp%2Four-vision-api+is%3Apr+is%3Aclosed+c1947d7+6957669+5498f4c+da963d7: 403 - You have exceeded a secondary rate limit. Please wait a few minutes before you try again. If you reach out to GitHub Support for help, please include the request ID 6240:2F3D38:AD61CB:14A80E5:65E914BD. // See: https://docs.github.com/free-pro-team@latest/rest/overview/rate-limits-for-the-rest-api#about-secondary-rate-limits (Octokit::TooManyRequests)
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/faraday-2.9.0/lib/faraday/middleware.rb:18:in `block in call'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/faraday-2.9.0/lib/faraday/response.rb:42:in `on_complete'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/faraday-2.9.0/lib/faraday/middleware.rb:17:in `call'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/octokit-8.1.0/lib/octokit/middleware/follow_redirects.rb:73:in `perform_with_redirection'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/octokit-8.1.0/lib/octokit/middleware/follow_redirects.rb:61:in `call'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/faraday-2.9.0/lib/faraday/rack_builder.rb:152:in `build_response'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/faraday-2.9.0/lib/faraday/connection.rb:444:in `run_request'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/faraday-2.9.0/lib/faraday/connection.rb:200:in `get'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/sawyer-0.9.2/lib/sawyer/agent.rb:99:in `call'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/octokit-8.1.0/lib/octokit/connection.rb:156:in `request'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/octokit-8.1.0/lib/octokit/connection.rb:84:in `paginate'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/octokit-8.1.0/lib/octokit/client/search.rb:99:in `search'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/octokit-8.1.0/lib/octokit/client/search.rb:49:in `search_issues'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/git-pr-release-2.2.0/lib/git/pr/release/cli.rb:145:in `search_issue_numbers'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/git-pr-release-2.2.0/lib/git/pr/release/cli.rb:179:in `fetch_squash_merged_pr_numbers_from_github'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/git-pr-release-2.2.0/lib/git/pr/release/cli.rb:101:in `fetch_merged_prs'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/git-pr-release-2.2.0/lib/git/pr/release/cli.rb:46:in `start'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/git-pr-release-2.2.0/lib/git/pr/release/cli.rb:12:in `start'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/lib/ruby/gems/3.1.0/gems/git-pr-release-2.2.0/exe/git-pr-release:5:in `<top (required)>'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/bin/git-pr-release:25:in `load'
	from /opt/hostedtoolcache/Ruby/3.1.4/x64/bin/git-pr-release:25:in `<main>'
Done.

```

The following article is helpful (in Japanese):

https://zenn.dev/snaka/scraps/574bf2f1dce400

# Changes

I have modified it so that if `search_issue_numbers` fails, it waits for 30 seconds and retries up to 3 times.

My company has been using the updated version for about a month, and the action, which previously failed about one out of every three times, now consistently succeeds. (Fail rate may depend on the project.)