### PR TITLE
Fix: Use conservative 200-char limit for search query length

### DIFF
--- a/lib/git/pr/release/cli.rb
+++ b/lib/git/pr/release/cli.rb
@@ -175,9 +175,13 @@ module Git
           # This is difficult to read from the current documentation, but that is the current
           # behavior and GitHub support has responded that this is the spec.
           shas.each do |sha|
-            # Longer than 256 characters are not supported in the query.
+            # GitHub documents a 256-character limit for search queries, but in practice
+            # the API enforces a stricter limit, likely due to URL-encoded length counting.
+            # Multiple users have reported errors at 220-240 characters, with 200 being stable.
             # ref. https://docs.github.com/en/rest/reference/search#limitations-on-query-length
-            if (query.length + 1 + sha.length) - query_base.length >= 256
+            # ref. https://github.com/x-motemen/git-pr-release/issues/103
+            # ref. https://github.com/orgs/community/discussions/186957
+            if query.length + 1 + sha.length >= 200
               pr_nums.concat(search_issue_numbers(query))
               query = query_base
             end

--- a/spec/git/pr/release/cli_spec.rb
+++ b/spec/git/pr/release/cli_spec.rb
@@ -730,11 +730,11 @@ RSpec.describe Git::Pr::Release::CLI do
     end
 
     context "When SHAs exceed query length limit" do
-      # Create enough SHAs to exceed the 256 character limit for the dynamic portion
-      # query_base = "repo:motemen/git-pr-release is:pr is:closed" (about 47 characters)
+      # query_base = "repo:motemen/git-pr-release is:pr is:closed" (44 characters)
       # Each SHA is 7 characters + 1 space = 8 characters
-      # To exceed 256 characters in dynamic part: 256 / 8 = 32 SHAs
-      let(:shas) { (1..35).map { |i| sprintf("%07d", i) } }
+      # Available space for SHAs: 200 - 44 = 156 characters
+      # To exceed the limit: 156 / 8 = ~19.5, so 20 SHAs will trigger a split
+      let(:shas) { (1..25).map { |i| sprintf("%07d", i) } }
 
       it "splits into multiple search requests" do
         subject
@@ -742,15 +742,12 @@ RSpec.describe Git::Pr::Release::CLI do
         expect(@cli).to have_received(:search_issue_numbers).at_least(2).times
       end
 
-      it "correctly calculates query length by subtracting query_base length" do
-        query_base = "repo:motemen/git-pr-release is:pr is:closed"
+      it "keeps total query length under 200 characters" do
         call_count = 0
 
         allow(@cli).to receive(:search_issue_numbers) do |query|
           call_count += 1
-          # Verify that each query's dynamic portion (excluding query_base) doesn't exceed 256 characters
-          dynamic_portion_length = query.length - query_base.length
-          expect(dynamic_portion_length).to be <= 256
+          expect(query.length).to be < 200
           [123]
         end
 


### PR DESCRIPTION
## Issue

#103


## Change

- Fix the query length check to use the **full query length** (including `repo:... is:pr is:closed` prefix) instead of only the dynamic SHA portion
- Lower the threshold from 256 to **200 characters** to account for GitHub API's undocumented stricter limit

## Rationale

The previous code had two issues:

1. **Incorrect length calculation**: The check `(query.length + 1 + sha.length) - query_base.length >= 256` subtracted `query_base.length`, so it only counted the SHA keywords against the 256-char limit. However, GitHub's Search API enforces the limit on the **entire** query string.

2. **Documented limit is inaccurate**: GitHub documents a 256-character limit, but in practice the API appears to count URL-encoded length internally (`:` → `%3A`, `/` → `%2F`), causing failures well below 256 characters. Multiple users confirmed:
   - Errors at 220–240 characters
   - Stable behavior at 200 characters
   - An independent experiment found 205 characters as the practical maximum

References:
- https://github.com/x-motemen/git-pr-release/issues/103
- https://github.com/orgs/community/discussions/186957
- https://zenn.dev/snaka/scraps/f8aaa97454de7a

## Impact

Each API request now carries fewer SHAs per batch (~19 instead of ~32 for a typical repository name). With the existing `sleep 1` between requests, this adds only a few seconds for typical workloads. For example, 60 commits would require ~3–4 requests instead of ~2, adding ~1–2 seconds of wall time — negligible compared to the reliability gain.
